### PR TITLE
[BUGFIX] Corrected key for 'Fluid uri image'

### DIFF
--- a/snippets/fluid.cson
+++ b/snippets/fluid.cson
@@ -50,7 +50,7 @@
   'Fluid uri page':
     'prefix': 'uri page'
     'body': '<f:uri.page pageUid="$1" />'
-  'Fluid uri page':
+  'Fluid uri image':
       'prefix': 'uri image'
       'body': '<f:uri.image image="$1" width="$2" height="$3" cropVariant="$4" />'
   'Fluid flash message':


### PR DESCRIPTION
There was a duplicate key in the file: 'Fluid uri page'. The second appearance should be named 'Fluid uri image'.